### PR TITLE
fixed content riding over nav bar on scroll

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -60,6 +60,7 @@ section h2 {
 .navbar {
     position: fixed;
     width: 100%;
+    z-index: 1;
 }
  /* End of Navigation bar  */
 


### PR DESCRIPTION
by setting a z-index on .navbar it's fixed the bug where some of the content was going over the top of the navbar when the page was scrolled